### PR TITLE
Reverting to spring-cloud-gcp-dependencies 5.6.1 due to crash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
-        <spring-cloud-gcp-dependencies.version>5.8.0</spring-cloud-gcp-dependencies.version>
+        <spring-cloud-gcp-dependencies.version>5.6.1</spring-cloud-gcp-dependencies.version>
         <consistgen.version>0.0.7</consistgen.version>
         <fileparamunit.version>0.0.5</fileparamunit.version>
     </properties>


### PR DESCRIPTION
A separate application was experiencing the following runtime crash when deploying

```
C [libio_grpc_netty_shaded_netty_tcnative_linux_x86_645219058936957356729.so+0x2a154] netty_internal_tcnative_SSLContext_JNI_OnLoad+0x9c4
```

This looks to be related to https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3296