### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/docker-build-dev.yml
+++ b/.github/workflows/docker-build-dev.yml
@@ -32,10 +32,10 @@ jobs:
         persist-credentials: false
     
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
     
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -46,7 +46,7 @@ jobs:
         echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: .
         push: true


### PR DESCRIPTION
Pin `actions/setup-go` and Docker actions to their resolved commit SHAs. These tags resolve to the exact same commits already pinned in 69+ other repos in the org.